### PR TITLE
Resolve Issue Updating Fail2ban ignoreip

### DIFF
--- a/scripts/tomav-user-patches.sh
+++ b/scripts/tomav-user-patches.sh
@@ -100,7 +100,7 @@ if [ ! -z "$WHITELIST_INT_NETWORKS" ]; then
     then
        ##mynetwork needs to be added
        echo "yo need to act for fail2ban, my network is $WHITELIST_INT_NETWORKS"
-       sed -i "/^ignoreip / s|$| $WHITELIST_INT_NETWORKS|" /etc/fail2ban/jail.conf
+       sed -i "s/^#ignoreip/ignoreip/;/^ignoreip / s|$| $WHITELIST_INT_NETWORKS|" /etc/fail2ban/jail.conf
        #supervisorctl restart fail2ban
     fi
 


### PR DESCRIPTION
I discovered that in recent builds of docker-mailserver, jail.conf has
the ignoreip line commented out, which resulted in this script failing
to append $WHITELIST_INT_NETWORKS to that line. Adding a sed expression
of "s/^#ignoreip/ignoreip/" seems to have resolved the issue.